### PR TITLE
docs+feat: add sandbox-import hint to proposer prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ def my_fn(...): ...
 ```
 `moderate` rejects proposals that call `eval` / `exec` / `os.system`, import `subprocess` / `socket` / `pickle` / `ctypes`, or touch `__globals__` / `__class__` / other escape hatches. `strict` additionally forbids any non-whitelisted import. The subprocess sandbox adds a real process boundary: args and return values are pickled over stdin/stdout, and the child inherits none of the caller's globals (proposals must be self-contained). See [Safety](#safety) for the full trust model.
 
+> **Sandbox + imports.** When `sandbox="subprocess"` is active, the child runs with `python -I` in a fresh namespace. **The repaired function must import every module it uses at the top of the definition.** `import math` at the caller module scope does NOT reach the sandbox, so a proposal that references `math.sqrt` without a local `import math` raises `NameError` on the first call. `self-heal` already hints at this in the LLM prompt when sandbox is active, but if you're writing a proposer by hand the same rule applies.
+
 ### Progress callbacks
 ```python
 from self_heal import repair, RepairEvent

--- a/src/self_heal/loop.py
+++ b/src/self_heal/loop.py
@@ -176,6 +176,7 @@ class RepairLoop:
             ctx.last_failure,
             history=list(ctx.attempts),
             extra=ctx.prompt_extra,
+            sandbox=(self.safety is not None and self.safety.sandbox == "subprocess"),
         )
 
         proposer = self.proposer
@@ -215,6 +216,7 @@ class RepairLoop:
             ctx.last_failure,
             history=list(ctx.attempts),
             extra=ctx.prompt_extra,
+            sandbox=(self.safety is not None and self.safety.sandbox == "subprocess"),
         )
 
         proposer = self.proposer

--- a/src/self_heal/propose.py
+++ b/src/self_heal/propose.py
@@ -47,16 +47,31 @@ PREVIOUS REPAIR ATTEMPTS — ALL FAILED. Do NOT propose any of these again:
 _CODE_BLOCK = re.compile(r"```(?:python)?\n?(.*?)```", re.DOTALL)
 
 
+SANDBOX_IMPORT_HINT = (
+    "\n\nIMPORTANT: this repair will run inside a fresh subprocess sandbox. "
+    "The child namespace does NOT inherit the caller's imports. "
+    "The repaired function MUST import every module it uses at the top of "
+    "the function body (e.g. `import math` inside the function), or the "
+    "first sandboxed call will raise NameError."
+)
+
+
 def build_messages(
     source: str,
     failure: Failure,
     history: list[RepairAttempt] | None = None,
     extra: str | None = None,
+    sandbox: bool = False,
 ) -> tuple[str, str]:
     """Build (system, user) prompt pair for a repair request.
 
     `history` lets the model see and avoid repeating prior failed fixes.
     `extra` is appended as free-form user instructions.
+    `sandbox` signals that the repair will run in a subprocess sandbox,
+    so the system prompt is extended with an explicit "import everything
+    you use" reminder (see :mod:`self_heal.sandbox`). Without this reminder
+    the LLM often omits module-level imports (e.g. `math`), and the first
+    sandboxed call fails with `NameError`.
     """
     history_section = _format_history(history) if history else ""
     extra_section = f"\nADDITIONAL USER INSTRUCTIONS:\n{extra}\n" if extra else ""
@@ -71,7 +86,8 @@ def build_messages(
         history_section=history_section,
         extra_section=extra_section,
     )
-    return REPAIR_SYSTEM, user
+    system = REPAIR_SYSTEM + SANDBOX_IMPORT_HINT if sandbox else REPAIR_SYSTEM
+    return system, user
 
 
 def extract_code(text: str) -> str:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,3 +153,39 @@ def test_decorator_returns_none_on_failure_when_configured():
 def test_rejects_invalid_max_attempts():
     with pytest.raises(ValueError):
         RepairLoop(max_attempts=0)
+
+
+def test_build_messages_sandbox_hint_absent_by_default() -> None:
+    """Without sandbox=True, the system prompt is the base REPAIR_SYSTEM."""
+    from self_heal.propose import REPAIR_SYSTEM, build_messages
+    from self_heal.types import Failure
+
+    failure = Failure(
+        kind="exception",
+        error_type="ValueError",
+        message="bad input",
+        inputs={},
+        traceback=None,
+    )
+    system, _ = build_messages("def f(): pass", failure)
+    assert system == REPAIR_SYSTEM
+    assert "subprocess sandbox" not in system
+
+
+def test_build_messages_sandbox_hint_added_when_flag_set() -> None:
+    """sandbox=True appends the SANDBOX_IMPORT_HINT explaining that the
+    proposed function must import every module it uses."""
+    from self_heal.propose import REPAIR_SYSTEM, SANDBOX_IMPORT_HINT, build_messages
+    from self_heal.types import Failure
+
+    failure = Failure(
+        kind="exception",
+        error_type="NameError",
+        message="name 'math' is not defined",
+        inputs={},
+        traceback=None,
+    )
+    system, _ = build_messages("def f(x): return math.sqrt(x)", failure, sandbox=True)
+    assert system == REPAIR_SYSTEM + SANDBOX_IMPORT_HINT
+    assert "subprocess sandbox" in system
+    assert "import every module" in system


### PR DESCRIPTION
## Summary

Addresses #14 at the prompt + docs layer: when `SafetyConfig(sandbox="subprocess")` is active, self-heal now explicitly reminds both the reader (via README) and the LLM (via the system prompt) that the sandbox child starts with a fresh namespace and the proposed function must import every module it uses.

## Why this matters

`src/self_heal/sandbox.py` runs the child with `python -I` inside `{"__name__": "__sandbox__"}`, so the caller's module-level imports are NOT inherited. The README's Safety section already mentioned this briefly ("the child inherits none of the caller's globals, so proposals must be self-contained"), but the one-sentence form is easy to miss, and -- more importantly -- the system prompt never told the LLM the rule. In practice, users who enabled `sandbox="subprocess"` would get proposals that used `math.sqrt` / `re.match` / etc. without any `import math` / `import re`, and the first sandboxed call would raise `NameError`. Issue #14 documents exactly this bite.

## Changes

- **README.md, Safety section**: adds a `> **Sandbox + imports.**` callout block that states the rule explicitly (imports must live inside the repaired function, `import math` at caller-module scope does not reach the sandbox) and points at where the LLM hint lives for hand-rolled proposers.
- **src/self_heal/propose.py**:
  - New `SANDBOX_IMPORT_HINT` string (module-level constant, exported for tests).
  - New `sandbox: bool = False` parameter on `build_messages`. When `True`, the returned system prompt is `REPAIR_SYSTEM + SANDBOX_IMPORT_HINT`; when `False`, callers get the old `REPAIR_SYSTEM` unchanged (backward-compatible).
- **src/self_heal/loop.py**: both `_obtain_repair` and `_aobtain_repair` pass `sandbox=(self.safety is not None and self.safety.sandbox == "subprocess")` into `build_messages`. The hint is added only when the repair will actually run in a subprocess sandbox.
- **tests/test_core.py**: two tests pin the behaviour -- one guards against accidental prompt inflation when sandbox is off, one asserts the hint content when sandbox is on.

## Scope

This closes fix ideas 1 and 2 from the issue (README callout + proposer-prompt hint). Fix idea 3 (wrap sandbox `NameError` into a `SandboxError` that hints at "missing import in sandboxed proposal") is a separate change to `src/self_heal/sandbox.py`'s exception path and is left for a follow-up -- happy to open a separate PR for that if preferred.

## Testing

```
$ python -m pytest tests/ -x -q
92 passed, 1 skipped (claude_agent_sdk not installed)
```

New tests:
- `test_build_messages_sandbox_hint_absent_by_default` -- prompt unchanged when `sandbox=False`
- `test_build_messages_sandbox_hint_added_when_flag_set` -- `SANDBOX_IMPORT_HINT` appended when `sandbox=True`, hint mentions "subprocess sandbox" and "import every module"

Closes #14 (partial)

---

This contribution was developed with AI assistance (Claude Code).
