### PR TITLE
feat(llm): add FireworksProposer and TogetherProposer convenience wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ pip install 'self-heal-llm[all]'       # everything
 |---|---|
 | `ClaudeProposer` | Anthropic Claude (native SDK) |
 | `OpenAIProposer` | OpenAI + **any OpenAI-compatible endpoint** (OpenRouter, Together, Groq, Fireworks, Anyscale, Perplexity, xAI, DeepSeek, Azure, Ollama, LM Studio, vLLM, llama.cpp server, ...) |
+| `FireworksProposer` | Fireworks AI (Llama, Qwen, Mixtral, DeepSeek hosted models) |
+| `TogetherProposer` | Together AI (Llama, Qwen, DeepSeek hosted models) |
 | `GeminiProposer` | Google Gemini (native SDK) |
 | `LiteLLMProposer` | 100+ providers via LiteLLM (Bedrock, Vertex, Cohere, Mistral, ...) |
 

--- a/src/self_heal/__init__.py
+++ b/src/self_heal/__init__.py
@@ -16,16 +16,25 @@ from self_heal.verify import Test, Verifier, check_tests, check_verifier
 if TYPE_CHECKING:
     from self_heal.llm import (
         ClaudeProposer,
+        FireworksProposer,
         GeminiProposer,
         LiteLLMProposer,
         OpenAIProposer,
+        TogetherProposer,
     )
 
 __version__ = "0.4.2"
 
 
 def __getattr__(name: str) -> Any:
-    if name in {"ClaudeProposer", "OpenAIProposer", "GeminiProposer", "LiteLLMProposer"}:
+    if name in {
+        "ClaudeProposer",
+        "FireworksProposer",
+        "GeminiProposer",
+        "LiteLLMProposer",
+        "OpenAIProposer",
+        "TogetherProposer",
+    }:
         from self_heal import llm
 
         return getattr(llm, name)
@@ -36,6 +45,7 @@ __all__ = [
     "ClaudeProposer",
     "EventCallback",
     "Failure",
+    "FireworksProposer",
     "GeminiProposer",
     "LLMProposer",
     "LiteLLMProposer",
@@ -47,6 +57,7 @@ __all__ = [
     "RepairResult",
     "SafetyConfig",
     "Test",
+    "TogetherProposer",
     "UnsafeProposalError",
     "Verifier",
     "check_tests",

--- a/src/self_heal/llm/__init__.py
+++ b/src/self_heal/llm/__init__.py
@@ -17,9 +17,11 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from self_heal.llm._claude import ClaudeProposer
+    from self_heal.llm._fireworks import FireworksProposer
     from self_heal.llm._gemini import GeminiProposer
     from self_heal.llm._litellm import LiteLLMProposer
     from self_heal.llm._openai import OpenAIProposer
+    from self_heal.llm._together import TogetherProposer
 
 
 class LLMProposer(Protocol):
@@ -47,10 +49,10 @@ def __getattr__(name: str) -> Any:
         from self_heal.llm._claude import ClaudeProposer
 
         return ClaudeProposer
-    if name == "OpenAIProposer":
-        from self_heal.llm._openai import OpenAIProposer
+    if name == "FireworksProposer":
+        from self_heal.llm._fireworks import FireworksProposer
 
-        return OpenAIProposer
+        return FireworksProposer
     if name == "GeminiProposer":
         from self_heal.llm._gemini import GeminiProposer
 
@@ -59,13 +61,23 @@ def __getattr__(name: str) -> Any:
         from self_heal.llm._litellm import LiteLLMProposer
 
         return LiteLLMProposer
+    if name == "OpenAIProposer":
+        from self_heal.llm._openai import OpenAIProposer
+
+        return OpenAIProposer
+    if name == "TogetherProposer":
+        from self_heal.llm._together import TogetherProposer
+
+        return TogetherProposer
     raise AttributeError(f"module 'self_heal.llm' has no attribute {name!r}")
 
 
 __all__ = [
     "ClaudeProposer",
+    "FireworksProposer",
     "GeminiProposer",
     "LLMProposer",
     "LiteLLMProposer",
     "OpenAIProposer",
+    "TogetherProposer",
 ]

--- a/src/self_heal/llm/_fireworks.py
+++ b/src/self_heal/llm/_fireworks.py
@@ -28,9 +28,16 @@ class FireworksProposer(OpenAIProposer):
         api_key: str | None = None,
         max_tokens: int | None = None,
     ) -> None:
+        resolved_key = api_key or os.environ.get("FIREWORKS_API_KEY")
+        if resolved_key is None:
+            raise ValueError(
+                "FireworksProposer requires a Fireworks API key. "
+                "Set FIREWORKS_API_KEY or pass api_key=...; "
+                "OPENAI_API_KEY is intentionally NOT used here."
+            )
         super().__init__(
             model=model,
-            api_key=api_key or os.environ.get("FIREWORKS_API_KEY"),
+            api_key=resolved_key,
             base_url="https://api.fireworks.ai/inference/v1",
             max_tokens=max_tokens,
         )

--- a/src/self_heal/llm/_fireworks.py
+++ b/src/self_heal/llm/_fireworks.py
@@ -1,0 +1,36 @@
+"""Fireworks AI proposer (OpenAI-compatible wrapper)."""
+
+from __future__ import annotations
+
+import os
+
+from self_heal.llm._openai import OpenAIProposer
+
+
+class FireworksProposer(OpenAIProposer):
+    """Fireworks-backed proposer.
+
+    Thin wrapper over :class:`OpenAIProposer` with Fireworks defaults:
+
+    - ``model`` defaults to ``accounts/fireworks/models/llama-v3p3-70b-instruct``
+    - ``api_key`` defaults to ``FIREWORKS_API_KEY`` env var
+    - ``base_url`` is pinned to ``https://api.fireworks.ai/inference/v1``
+
+    Example::
+
+        p = FireworksProposer()
+        p = FireworksProposer(model="accounts/fireworks/models/qwen3-235b-a22b")
+    """
+
+    def __init__(
+        self,
+        model: str = "accounts/fireworks/models/llama-v3p3-70b-instruct",
+        api_key: str | None = None,
+        max_tokens: int | None = None,
+    ) -> None:
+        super().__init__(
+            model=model,
+            api_key=api_key or os.environ.get("FIREWORKS_API_KEY"),
+            base_url="https://api.fireworks.ai/inference/v1",
+            max_tokens=max_tokens,
+        )

--- a/src/self_heal/llm/_together.py
+++ b/src/self_heal/llm/_together.py
@@ -28,9 +28,16 @@ class TogetherProposer(OpenAIProposer):
         api_key: str | None = None,
         max_tokens: int | None = None,
     ) -> None:
+        resolved_key = api_key or os.environ.get("TOGETHER_API_KEY")
+        if resolved_key is None:
+            raise ValueError(
+                "TogetherProposer requires a Together API key. "
+                "Set TOGETHER_API_KEY or pass api_key=...; "
+                "OPENAI_API_KEY is intentionally NOT used here."
+            )
         super().__init__(
             model=model,
-            api_key=api_key or os.environ.get("TOGETHER_API_KEY"),
+            api_key=resolved_key,
             base_url="https://api.together.xyz/v1",
             max_tokens=max_tokens,
         )

--- a/src/self_heal/llm/_together.py
+++ b/src/self_heal/llm/_together.py
@@ -1,0 +1,36 @@
+"""Together AI proposer (OpenAI-compatible wrapper)."""
+
+from __future__ import annotations
+
+import os
+
+from self_heal.llm._openai import OpenAIProposer
+
+
+class TogetherProposer(OpenAIProposer):
+    """Together-backed proposer.
+
+    Thin wrapper over :class:`OpenAIProposer` with Together defaults:
+
+    - ``model`` defaults to ``meta-llama/Llama-3.3-70B-Instruct-Turbo``
+    - ``api_key`` defaults to ``TOGETHER_API_KEY`` env var
+    - ``base_url`` is pinned to ``https://api.together.xyz/v1``
+
+    Example::
+
+        p = TogetherProposer()
+        p = TogetherProposer(model="meta-llama/Llama-3.1-70B-Instruct-Turbo")
+    """
+
+    def __init__(
+        self,
+        model: str = "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        api_key: str | None = None,
+        max_tokens: int | None = None,
+    ) -> None:
+        super().__init__(
+            model=model,
+            api_key=api_key or os.environ.get("TOGETHER_API_KEY"),
+            base_url="https://api.together.xyz/v1",
+            max_tokens=max_tokens,
+        )

--- a/tests/test_proposers.py
+++ b/tests/test_proposers.py
@@ -334,3 +334,67 @@ def test_repair_loop_rejects_invalid_max_attempts():
 
     with pytest.raises(ValueError):
         RepairLoop(max_attempts=0)
+
+
+# ---------------------------------------------------------------------------
+# FireworksProposer
+# ---------------------------------------------------------------------------
+
+
+def test_fireworks_proposer_uses_fireworks_defaults(monkeypatch):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw-test-key")
+    mock_client = MagicMock()
+    with patch("self_heal.llm._openai.OpenAI", return_value=mock_client) as mock_openai:
+        from self_heal.llm import FireworksProposer
+
+        FireworksProposer()
+
+    mock_openai.assert_called_once_with(
+        api_key="fw-test-key",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+
+def test_fireworks_proposer_accepts_explicit_api_key():
+    mock_client = MagicMock()
+    with patch("self_heal.llm._openai.OpenAI", return_value=mock_client) as mock_openai:
+        from self_heal.llm import FireworksProposer
+
+        FireworksProposer(api_key="explicit-fw-key")
+
+    mock_openai.assert_called_once_with(
+        api_key="explicit-fw-key",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# TogetherProposer
+# ---------------------------------------------------------------------------
+
+
+def test_together_proposer_uses_together_defaults(monkeypatch):
+    monkeypatch.setenv("TOGETHER_API_KEY", "tg-test-key")
+    mock_client = MagicMock()
+    with patch("self_heal.llm._openai.OpenAI", return_value=mock_client) as mock_openai:
+        from self_heal.llm import TogetherProposer
+
+        TogetherProposer()
+
+    mock_openai.assert_called_once_with(
+        api_key="tg-test-key",
+        base_url="https://api.together.xyz/v1",
+    )
+
+
+def test_together_proposer_accepts_explicit_api_key():
+    mock_client = MagicMock()
+    with patch("self_heal.llm._openai.OpenAI", return_value=mock_client) as mock_openai:
+        from self_heal.llm import TogetherProposer
+
+        TogetherProposer(api_key="explicit-tg-key")
+
+    mock_openai.assert_called_once_with(
+        api_key="explicit-tg-key",
+        base_url="https://api.together.xyz/v1",
+    )


### PR DESCRIPTION
## Summary

Adds `FireworksProposer` and `TogetherProposer` as thin convenience subclasses of `OpenAIProposer`, fulfilling #21. Both pin provider-specific `base_url` values, default `model`s, and env vars (`FIREWORKS_API_KEY` / `TOGETHER_API_KEY`), so the one-line import path is:

```python
from self_heal import FireworksProposer, TogetherProposer

p = FireworksProposer()  # reads FIREWORKS_API_KEY
p = TogetherProposer(model="meta-llama/Llama-3.1-70B-Instruct-Turbo")
```

## Why this matters

#21 was filed 2026-04-18 with the exact pattern I copied here -- `OpenAIProposer` already covers both providers via `base_url`, but the `good first issue` argues that explicit wrappers give users a one-line import and sensible provider defaults. The maintainer called out two concrete wins: env var mapping (so `FIREWORKS_API_KEY` "just works") and no new optional-dependency entry (reuse `[openai]`). That matches the shape of the existing `OpenAIProposer` path I found in `src/self_heal/llm/_openai.py`: it takes `model`, `api_key`, `base_url`, `max_tokens`, falls back to `OPENAI_API_KEY` if `api_key` is `None`, and constructs `OpenAI(api_key=resolved, base_url=base_url)`. The new wrappers inherit that surface (`propose`, `apropose`, `propose_stream`, `_params`) for free -- they only carry the provider-specific defaults.

Verified against the existing lazy-export pattern too: `src/self_heal/llm/__init__.py` uses `TYPE_CHECKING` + `__getattr__` + `__all__`, and the top-level `src/self_heal/__init__.py` re-exports the four built-in proposers the same way. Both locations get the new classes so `from self_heal import FireworksProposer` and `from self_heal.llm import FireworksProposer` both work.

## Testing

- `PYTHONPATH=src pytest tests/test_proposers.py -q`: all 26 tests pass (22 existing + 4 new).
- `PYTHONPATH=src pytest -q`: full suite, 96 passed, 1 skipped (`claude_agent_sdk` optional dep not installed).
- `ruff check src/ tests/`: clean.

## Known limitations (out of scope)

`OpenAIProposer._params()` serializes `max_tokens` as `max_completion_tokens` (the newer OpenAI field used by o1/gpt-5). Fireworks and Together both accept `max_completion_tokens` on their OpenAI-compatible chat endpoints today, but if they ever stop, these wrappers would need to override `_params()` to map back to the classic `max_tokens` key. Happy to file a follow-up if you want a provider-specific override now; it felt out of scope for this issue which specifically asked for a thin convenience wrapper.

Fixes #21

This contribution was developed with AI assistance (Codex).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
