### PR TITLE
feat(llm): add GroqProposer convenience wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ pip install 'self-heal-llm[all]'       # everything
 |---|---|
 | `ClaudeProposer` | Anthropic Claude (native SDK) |
 | `OpenAIProposer` | OpenAI + **any OpenAI-compatible endpoint** (OpenRouter, Together, Groq, Fireworks, Anyscale, Perplexity, xAI, DeepSeek, Azure, Ollama, LM Studio, vLLM, llama.cpp server, ...) |
+| `GroqProposer` | Groq (OpenAI-compatible; reads `GROQ_API_KEY`, defaults to Llama 3.3 70B) |
 | `GeminiProposer` | Google Gemini (native SDK) |
 | `LiteLLMProposer` | 100+ providers via LiteLLM (Bedrock, Vertex, Cohere, Mistral, ...) |
 

--- a/src/self_heal/llm/__init__.py
+++ b/src/self_heal/llm/__init__.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 if TYPE_CHECKING:
     from self_heal.llm._claude import ClaudeProposer
     from self_heal.llm._gemini import GeminiProposer
+    from self_heal.llm._groq import GroqProposer
     from self_heal.llm._litellm import LiteLLMProposer
     from self_heal.llm._openai import OpenAIProposer
 
@@ -51,6 +52,10 @@ def __getattr__(name: str) -> Any:
         from self_heal.llm._openai import OpenAIProposer
 
         return OpenAIProposer
+    if name == "GroqProposer":
+        from self_heal.llm._groq import GroqProposer
+
+        return GroqProposer
     if name == "GeminiProposer":
         from self_heal.llm._gemini import GeminiProposer
 
@@ -65,6 +70,7 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "ClaudeProposer",
     "GeminiProposer",
+    "GroqProposer",
     "LLMProposer",
     "LiteLLMProposer",
     "OpenAIProposer",

--- a/src/self_heal/llm/_groq.py
+++ b/src/self_heal/llm/_groq.py
@@ -1,0 +1,36 @@
+"""Groq proposer (OpenAI-compatible)."""
+
+from __future__ import annotations
+
+import os
+
+from self_heal.llm._openai import OpenAIProposer
+
+
+class GroqProposer(OpenAIProposer):
+    """Groq-backed proposer over the OpenAI-compatible endpoint.
+
+    Reads `GROQ_API_KEY` from the environment unless `api_key` is passed.
+    Defaults `base_url` to `https://api.groq.com/openai/v1` and uses Groq's
+    Llama 3.3 70B as the default model. Otherwise behaves exactly like
+    `OpenAIProposer`.
+
+    Example:
+        from self_heal.llm import GroqProposer
+
+        proposer = GroqProposer()
+        proposer = GroqProposer(model="llama-3.1-8b-instant")
+    """
+
+    def __init__(
+        self,
+        model: str = "llama-3.3-70b-versatile",
+        api_key: str | None = None,
+        max_tokens: int | None = None,
+    ):
+        super().__init__(
+            model=model,
+            api_key=api_key or os.environ.get("GROQ_API_KEY"),
+            base_url="https://api.groq.com/openai/v1",
+            max_tokens=max_tokens,
+        )

--- a/tests/test_proposers.py
+++ b/tests/test_proposers.py
@@ -1,4 +1,4 @@
-"""Unit tests for the four LLM proposer adapters.
+"""Unit tests for the five LLM proposer adapters.
 
 All tests mock the underlying SDK — no network calls, no API keys needed.
 """
@@ -12,6 +12,7 @@ import pytest
 from self_heal.llm import (
     ClaudeProposer,
     GeminiProposer,
+    GroqProposer,
     LiteLLMProposer,
     OpenAIProposer,
 )
@@ -167,6 +168,29 @@ def test_openai_proposer_handles_none_content():
         result = OpenAIProposer(api_key="x").propose("s", "u")
 
     assert result == ""
+
+
+def test_groq_proposer_sets_default_base_url_and_model(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "env-groq-key")
+    with patch("self_heal.llm._openai.OpenAI") as MockOpenAI:
+        proposer = GroqProposer()
+
+    MockOpenAI.assert_called_once_with(
+        api_key="env-groq-key",
+        base_url="https://api.groq.com/openai/v1",
+    )
+    assert proposer.model == "llama-3.3-70b-versatile"
+
+
+def test_groq_proposer_explicit_api_key_overrides_env(monkeypatch):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    with patch("self_heal.llm._openai.OpenAI") as MockOpenAI:
+        GroqProposer(api_key="explicit")
+
+    MockOpenAI.assert_called_once_with(
+        api_key="explicit",
+        base_url="https://api.groq.com/openai/v1",
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `GroqProposer` as a thin subclass of `OpenAIProposer`. Reads `GROQ_API_KEY` from the environment, defaults `base_url` to `https://api.groq.com/openai/v1`, and uses `llama-3.3-70b-versatile` as the default model.

## What's covered (issue acceptance)

- [x] Lint + tests green (`ruff check`: clean; `pytest -q`: 98 passed, 1 SDK-import skip)
- [x] README updated (new provider-table row right below `OpenAIProposer`)
- [x] No live API calls (tests use the same `patch("self_heal.llm._openai.OpenAI", ...)` mock pattern as the existing `OpenAIProposer` tests)

Closes #19

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
