### PR TITLE
fix: re-export Groq and Cohere proposers

### DIFF
--- a/src/self_heal/__init__.py
+++ b/src/self_heal/__init__.py
@@ -16,8 +16,10 @@ from self_heal.verify import Test, Verifier, check_tests, check_verifier
 if TYPE_CHECKING:
     from self_heal.llm import (
         ClaudeProposer,
+        CohereProposer,
         FireworksProposer,
         GeminiProposer,
+        GroqProposer,
         LiteLLMProposer,
         OpenAIProposer,
         TogetherProposer,
@@ -29,8 +31,10 @@ __version__ = "0.5.0"
 def __getattr__(name: str) -> Any:
     if name in {
         "ClaudeProposer",
+        "CohereProposer",
         "FireworksProposer",
         "GeminiProposer",
+        "GroqProposer",
         "LiteLLMProposer",
         "OpenAIProposer",
         "TogetherProposer",
@@ -43,10 +47,12 @@ def __getattr__(name: str) -> Any:
 
 __all__ = [
     "ClaudeProposer",
+    "CohereProposer",
     "EventCallback",
     "Failure",
     "FireworksProposer",
     "GeminiProposer",
+    "GroqProposer",
     "LLMProposer",
     "LiteLLMProposer",
     "OpenAIProposer",


### PR DESCRIPTION
## Summary
- re-export `GroqProposer` and `CohereProposer` from top-level `self_heal`
- add both names to the lazy export allowlist, `TYPE_CHECKING` imports, and `__all__`

Closes #29

## Testing
- `python -c "from self_heal import GroqProposer, CohereProposer"`
- `python -c "import self_heal; print(sorted(self_heal.__all__))"`
- `ruff check .`
- `pytest`
