### PR TITLE
docs: document install commands for Groq/Fireworks/Together adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ pip install 'self-heal-llm[litellm]'   # 100+ providers via LiteLLM
 pip install 'self-heal-llm[all]'       # everything
 ```
 
+> **Note:** The `GroqProposer`, `FireworksProposer`, and `TogetherProposer` adapters share the `openai` SDK; install with `pip install 'self-heal-llm[openai]'`.
+
 > PyPI distribution name is `self-heal-llm` (the short name `self-heal` was blocked by PyPI's similarity check with an unrelated package). The Python import stays `from self_heal import ...`.
 
 ## Provider support


### PR DESCRIPTION
Add a note explaining that GroqProposer, FireworksProposer, and TogetherProposer adapters share the openai SDK and can be installed with `pip install 'self-heal-llm[openai]'`.

This follows Option A from the issue - documenting the piggyback explicitly without code changes.

Closes #30