### PR TITLE
tests: smoke-test examples/ imports to catch silent rot (fixes #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ Examples in [`examples/`](examples):
 - [`with_langchain.py`](examples/with_langchain.py)
 - [`with_crewai.py`](examples/with_crewai.py)
 
+All examples are smoke-tested on every CI run via [`tests/test_examples_import.py`](tests/test_examples_import.py).
+
 ## Safety
 
 `self-heal` executes LLM-generated code via `exec()` in the same process by default. Three layers of defense are available:

--- a/tests/test_examples_import.py
+++ b/tests/test_examples_import.py
@@ -1,0 +1,58 @@
+"""Smoke-test every example under examples/.
+
+Ensures that examples parse and import cleanly after refactors.
+
+Rules
+-----
+ImportError naming a known optional SDK  -> pytest.skip (expected in bare envs)
+SDK raising on missing credentials       -> pytest.skip (optional, not configured)
+Any other exception                      -> fail (real bug)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_OPTIONAL_PACKAGES = {
+    "anthropic", "openai", "google", "cohere",
+    "mistralai", "crewai", "langchain", "agents",
+    "claude_agent_sdk",
+}
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+EXAMPLE_FILES = sorted(EXAMPLES_DIR.rglob("*.py"))
+
+
+def _is_optional_import_error(exc: ImportError) -> bool:
+    msg = str(exc).lower()
+    return any(pkg in msg for pkg in _OPTIONAL_PACKAGES)
+
+
+def _is_credential_error(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return "api key" in msg or "api_key" in msg or "credential" in msg
+
+
+@pytest.mark.parametrize("example_path", EXAMPLE_FILES, ids=lambda p: p.name)
+def test_example_imports(example_path: Path) -> None:
+    if str(EXAMPLES_DIR) not in sys.path:
+        sys.path.insert(0, str(EXAMPLES_DIR))
+
+    spec = importlib.util.spec_from_file_location(example_path.stem, example_path)
+    assert spec and spec.loader, f"Could not create spec for {example_path.name}"
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+    except ImportError as exc:
+        if _is_optional_import_error(exc):
+            pytest.skip(f"Optional dependency not installed -- {exc}")
+        raise
+    except Exception as exc:
+        if _is_credential_error(exc):
+            pytest.skip(f"Optional SDK not configured -- {exc}")
+        raise


### PR DESCRIPTION
**Closes #36**

## Problem

The `examples/` directory ships demo Python files that are never imported or executed during CI. This means that if a refactor renames a module, removes a symbol, or introduces a syntax error, the examples silently break — no one notices until a user copy-pastes the example and gets a stack trace.

## What this PR does

Adds `tests/test_examples_import.py` — a lightweight parametrized smoke test that imports every `.py` file under `examples/` as part of the existing pytest suite. No new CI job needed.

## How it works

For each example file, the test:

1. Builds an import spec using `importlib.util.spec_from_file_location`
2. Creates a module object with `module_from_spec`
3. Executes it with `spec.loader.exec_module` — this runs the file's top-level code (imports, decorator applications) without triggering any `if __name__ == "__main__"` block

This catches exactly what the issue describes — import-from-removed-module breakage, missing dependencies that examples expect, and syntax errors introduced by a refactor.

## Skip vs Fail logic

Not every example can import cleanly in a bare environment, and that's expected. The test distinguishes two cases:

**Skip** — optional SDK not available or not configured:
- `ImportError` whose message names a known optional package (`anthropic`, `openai`, `google`, `cohere`, `crewai`, `langchain`, etc.) → `pytest.skip`
- SDK raising on missing credentials at construction time → `pytest.skip` (needed for `with_crewai.py` and `with_openai_agents.py` which instantiate `GeminiProposer` and `OpenAIProposer` at decoration time — before any function is ever called — so a missing API key surfaces as a `ValueError`/`OpenAIError` rather than an `ImportError`)

**Fail** — anything else: a broken import after a rename, a `SyntaxError`, an unexpected runtime error at module level. These are real bugs that the test is designed to catch.

## Results locally

```
10 collected
8 passed   — all core examples import cleanly
2 skipped  — with_crewai.py (no GEMINI_API_KEY), with_openai_agents.py (no OPENAI_API_KEY)
0 failed
```

Full suite: 118 passed, 2 skipped, 0 failed — no regressions.