### PR TITLE
feat(cohere): add async and streaming proposer paths

### DIFF
--- a/src/self_heal/llm/_cohere.py
+++ b/src/self_heal/llm/_cohere.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 
 try:
-    from cohere import ClientV2
+    from cohere import AsyncClientV2, ClientV2
 except ImportError as _err:  # pragma: no cover
     raise ImportError(
         "CohereProposer requires the `cohere` package. "
@@ -33,7 +33,15 @@ class CohereProposer:
         self.model = model
         self.max_tokens = max_tokens
         key = api_key or os.environ.get("COHERE_API_KEY")
+        self._api_key = key
         self.client = ClientV2(api_key=key)
+        self._aclient: AsyncClientV2 | None = None
+
+    @property
+    def aclient(self) -> AsyncClientV2:
+        if self._aclient is None:
+            self._aclient = AsyncClientV2(api_key=self._api_key)
+        return self._aclient
 
     def _params(self, system: str, user: str) -> dict:
         params: dict = {
@@ -51,9 +59,42 @@ class CohereProposer:
         response = self.client.chat(**self._params(system, user))
         return _extract_text(response)
 
+    async def apropose(self, system: str, user: str) -> str:
+        response = await self.aclient.chat(**self._params(system, user))
+        return _extract_text(response)
+
+    def propose_stream(self, system: str, user: str):
+        stream = self.client.chat_stream(**self._params(system, user))
+        for chunk in stream:
+            delta = _extract_delta_text(chunk)
+            if delta:
+                yield delta
+
+    async def apropose_stream(self, system: str, user: str):
+        stream = self.aclient.chat_stream(**self._params(system, user))
+        async for chunk in stream:
+            delta = _extract_delta_text(chunk)
+            if delta:
+                yield delta
+
 
 def _extract_text(response) -> str:
     message = getattr(response, "message", None)
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return content
+    if not content:
+        return ""
+    for block in content:
+        text = getattr(block, "text", None)
+        if text:
+            return text
+    return ""
+
+
+def _extract_delta_text(chunk) -> str:
+    delta = getattr(chunk, "delta", None)
+    message = getattr(delta, "message", None)
     content = getattr(message, "content", None)
     if isinstance(content, str):
         return content

--- a/tests/test_proposers.py
+++ b/tests/test_proposers.py
@@ -5,7 +5,9 @@ All tests mock the underlying SDK — no network calls, no API keys needed.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -109,6 +111,19 @@ def _cohere_response(content: str | None) -> MagicMock:
     return response
 
 
+def _cohere_stream_chunk(content: str | None) -> SimpleNamespace:
+    block = SimpleNamespace(text=content)
+    return SimpleNamespace(
+        delta=SimpleNamespace(message=SimpleNamespace(content=[block]))
+    )
+
+
+async def _async_iter(items):
+    for item in items:
+        await asyncio.sleep(0)
+        yield item
+
+
 def test_cohere_proposer_returns_message_content():
     mock_client = MagicMock()
     mock_client.chat.return_value = _cohere_response("def foo(): return 42")
@@ -156,6 +171,79 @@ def test_cohere_proposer_handles_empty_content():
         result = CohereProposer(api_key="x").propose("s", "u")
 
     assert result == ""
+
+
+def test_cohere_proposer_uses_native_async_client():
+    mock_sync_client = MagicMock()
+    mock_async_client = MagicMock()
+    mock_async_client.chat = AsyncMock(
+        return_value=_cohere_response("async repair")
+    )
+
+    with (
+        patch("self_heal.llm._cohere.ClientV2", return_value=mock_sync_client),
+        patch("self_heal.llm._cohere.AsyncClientV2", return_value=mock_async_client),
+    ):
+        proposer = CohereProposer(model="command-r-plus", api_key="test")
+        result = asyncio.run(proposer.apropose("sys", "user"))
+
+    assert result == "async repair"
+    mock_sync_client.chat.assert_not_called()
+    kwargs = mock_async_client.chat.call_args.kwargs
+    assert kwargs["model"] == "command-r-plus"
+    assert kwargs["messages"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "user"},
+    ]
+
+
+def test_cohere_proposer_streams_text_chunks():
+    mock_client = MagicMock()
+    mock_client.chat_stream.return_value = [
+        _cohere_stream_chunk("def "),
+        _cohere_stream_chunk("foo"),
+        _cohere_stream_chunk(None),
+    ]
+
+    with patch("self_heal.llm._cohere.ClientV2", return_value=mock_client):
+        proposer = CohereProposer(api_key="test")
+        chunks = list(proposer.propose_stream("sys", "user"))
+
+    assert chunks == ["def ", "foo"]
+    kwargs = mock_client.chat_stream.call_args.kwargs
+    assert kwargs["messages"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "user"},
+    ]
+
+
+def test_cohere_proposer_streams_text_chunks_async():
+    mock_async_client = MagicMock()
+    mock_async_client.chat_stream.return_value = _async_iter(
+        [
+            _cohere_stream_chunk("async "),
+            _cohere_stream_chunk("foo"),
+            _cohere_stream_chunk(None),
+        ]
+    )
+
+    async def collect():
+        with (
+            patch("self_heal.llm._cohere.ClientV2"),
+            patch(
+                "self_heal.llm._cohere.AsyncClientV2",
+                return_value=mock_async_client,
+            ),
+        ):
+            proposer = CohereProposer(api_key="test")
+            return [chunk async for chunk in proposer.apropose_stream("sys", "user")]
+
+    assert asyncio.run(collect()) == ["async ", "foo"]
+    kwargs = mock_async_client.chat_stream.call_args.kwargs
+    assert kwargs["messages"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "user"},
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add native `apropose()` support for `CohereProposer` using `AsyncClientV2`
- add sync and async streaming paths for Cohere chat streams
- cover async and streaming Cohere behavior with mocked unit tests

Closes #31

## Testing
- `pytest tests/test_proposers.py -q`
- `ruff check .`
- `pytest`
