### PR TITLE
Add exponential backoff retry for transient LLM provider errors (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # self-heal
 
-[![CI](https://github.com/Johin2/self-heal/actions/workflows/ci.yml/badge.svg)](https://github.com/Johin2/self-heal/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/self-heal-llm.svg)](https://pypi.org/project/self-heal-llm/)
-[![Python](https://img.shields.io/pypi/pyversions/self-heal-llm.svg)](https://pypi.org/project/self-heal-llm/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[CI](https://github.com/Johin2/self-heal/actions/workflows/ci.yml)
+[PyPI](https://pypi.org/project/self-heal-llm/)
+[Python](https://pypi.org/project/self-heal-llm/)
+[License: MIT](LICENSE)
 
 > Automatic repair for failing Python code, powered by any LLM.
 
-![self-heal demo](assets/demo.gif)
+self-heal demo
 
 `self-heal` catches failures, proposes an LLM-guided fix with memory of prior attempts, verifies it, and retries. Works with Claude, OpenAI, Gemini, and 100+ other providers. Sync and async. One decorator.
 
@@ -32,19 +32,23 @@ Two suites, both run against Gemini 2.5 Flash, 3 max attempts, v0.4 harness.
 
 **Default suite** (19 hand-written bugs: price parsing, palindrome, flatten, roman numerals, camelCase-to-snake_case, Levenshtein, anagram, duration formatting, ...)
 
-| Strategy | Tasks passed | Success rate | LLM calls |
-|---|---:|---:|---:|
-| Naive single-shot repair | 16 / 19 | 84% | 17 |
-| **self-heal (multi-turn + memory)** | **18 / 19** | **95%** | 21 |
+
+| Strategy                            | Tasks passed | Success rate | LLM calls |
+| ----------------------------------- | ------------ | ------------ | --------- |
+| Naive single-shot repair            | 16 / 19      | 84%          | 17        |
+| **self-heal (multi-turn + memory)** | **18 / 19**  | **95%**      | 21        |
+
 
 **QuixBugs** (31 classic one-line bugs; 9 graph/tree programs skipped by the loader for custom-deserialization reasons)
 
-| Strategy | Tasks passed | Success rate | LLM calls |
-|---|---:|---:|---:|
-| Naive single-shot repair | 27 / 31 | 87% | 30 |
-| **self-heal (multi-turn + memory)** | **29 / 31** | **94%** | 35 |
 
-Reproduce: `self-heal bench --proposer gemini --model gemini-2.5-flash` (default) or `--suite quixbugs`. Full numbers, historical rows, and how to contribute your own in [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md). Task source in [`benchmarks/tasks.py`](benchmarks/tasks.py).
+| Strategy                            | Tasks passed | Success rate | LLM calls |
+| ----------------------------------- | ------------ | ------------ | --------- |
+| Naive single-shot repair            | 27 / 31      | 87%          | 30        |
+| **self-heal (multi-turn + memory)** | **29 / 31**  | **94%**      | 35        |
+
+
+Reproduce: `self-heal bench --proposer gemini --model gemini-2.5-flash` (default) or `--suite quixbugs`. Full numbers, historical rows, and how to contribute your own in `[benchmarks/RESULTS.md](benchmarks/RESULTS.md)`. Task source in `[benchmarks/tasks.py](benchmarks/tasks.py)`.
 
 The +2 tasks on each suite share a pattern: the first proposed fix handles one edge case but misses another. Memory of the failed attempt plus test feedback lets the second proposal cover both. Roughly 20% more LLM calls for the additional wins. As frontier models keep improving the naive floor rises and this delta compresses; earlier runs against Gemini 2.5 Flash had naive at 68% instead of 84%, which is honest signal not cherry-picked.
 
@@ -68,24 +72,28 @@ pip install 'self-heal-llm[all]'       # everything
 
 ## Provider support
 
-| Adapter | Covers |
-|---|---|
-| `ClaudeProposer` | Anthropic Claude (native SDK) |
-| `CohereProposer` | Cohere (native SDK) |
-| `OpenAIProposer` | OpenAI + **any OpenAI-compatible endpoint** (OpenRouter, Together, Groq, Fireworks, Anyscale, Perplexity, xAI, DeepSeek, Azure, Ollama, LM Studio, vLLM, llama.cpp server, ...) |
-| `GroqProposer` | Groq (OpenAI-compatible; reads `GROQ_API_KEY`, defaults to Llama 3.3 70B) |
-| `FireworksProposer` | Fireworks AI (Llama, Qwen, Mixtral, DeepSeek hosted models) |
-| `TogetherProposer` | Together AI (Llama, Qwen, DeepSeek hosted models) |
-| `GeminiProposer` | Google Gemini (native SDK) |
-| `MistralProposer` | Mistral AI (native SDK; reads `MISTRAL_API_KEY`, defaults to `mistral-large-latest`, supports sync / async / streaming) |
-| `LiteLLMProposer` | 100+ providers via LiteLLM (Bedrock, Vertex, Cohere, Mistral, ...) |
+
+| Adapter             | Covers                                                                                                                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ClaudeProposer`    | Anthropic Claude (native SDK)                                                                                                                                                   |
+| `CohereProposer`    | Cohere (native SDK)                                                                                                                                                             |
+| `OpenAIProposer`    | OpenAI + **any OpenAI-compatible endpoint** (OpenRouter, Together, Groq, Fireworks, Anyscale, Perplexity, xAI, DeepSeek, Azure, Ollama, LM Studio, vLLM, llama.cpp server, ...) |
+| `GroqProposer`      | Groq (OpenAI-compatible; reads `GROQ_API_KEY`, defaults to Llama 3.3 70B)                                                                                                       |
+| `FireworksProposer` | Fireworks AI (Llama, Qwen, Mixtral, DeepSeek hosted models)                                                                                                                     |
+| `TogetherProposer`  | Together AI (Llama, Qwen, DeepSeek hosted models)                                                                                                                               |
+| `GeminiProposer`    | Google Gemini (native SDK)                                                                                                                                                      |
+| `MistralProposer`   | Mistral AI (native SDK; reads `MISTRAL_API_KEY`, defaults to `mistral-large-latest`, supports sync / async / streaming)                                                         |
+| `LiteLLMProposer`   | 100+ providers via LiteLLM (Bedrock, Vertex, Cohere, Mistral, ...)                                                                                                              |
+
 
 ## Features
 
 ### Multi-turn repair with memory
+
 Every proposal sees the history of *prior failed attempts* so the LLM can't repeat the same mistake. This is the single biggest quality win over naive retry.
 
 ### Verifiers: `verify=callable`
+
 Catch bad *return values*, not just exceptions:
 
 ```python
@@ -96,6 +104,7 @@ def extract_price(text): ...
 If the predicate returns `False` or raises, self-heal treats it as a failure and repairs.
 
 ### Test-driven repair: `tests=[...]`
+
 Give self-heal a test suite; it repairs until every test passes:
 
 ```python
@@ -107,6 +116,7 @@ def extract_price(text): ...
 ```
 
 ### Async-native
+
 The decorator auto-detects `async def` and awaits correctly; the LLM call runs in a thread pool so your event loop stays free.
 
 ```python
@@ -115,21 +125,26 @@ async def fetch_and_parse(url: str) -> dict: ...
 ```
 
 ### Prompt customization: `prompt_extra="..."`
+
 Append domain-specific instructions to every repair prompt. Useful for "always handle None inputs" or "use only the standard library."
 
 ### Bring your own LLM
+
 Implement the `LLMProposer` Protocol (`def propose(self, system: str, user: str) -> str`) and pass it in.
 
 ### Repair cache: skip the LLM when you've seen it before
+
 ```python
 from self_heal import repair
 
 @repair(cache_path=".self_heal_cache.db")
 def my_fn(...): ...
 ```
+
 First repair hits the LLM. Subsequent identical failures are served from SQLite (zero latency, zero cost). Keyed on source hash + failure signature with whitespace and memory-address normalization.
 
 ### Safety: AST rails + subprocess sandbox
+
 Two independent layers. Combine them freely.
 
 ```python
@@ -143,11 +158,13 @@ def my_fn(...): ...
 @repair(safety=SafetyConfig(level="moderate", sandbox="subprocess"))
 def my_fn(...): ...
 ```
+
 `moderate` rejects proposals that call `eval` / `exec` / `os.system`, import `subprocess` / `socket` / `pickle` / `ctypes`, or touch `__globals__` / `__class__` / other escape hatches. `strict` additionally forbids any non-whitelisted import. The subprocess sandbox adds a real process boundary: args and return values are pickled over stdin/stdout, and the child inherits none of the caller's globals (proposals must be self-contained). See [Safety](#safety) for the full trust model.
 
 > **Sandbox + imports.** When `sandbox="subprocess"` is active, the child runs with `python -I` in a fresh namespace. **The repaired function must import every module it uses at the top of the definition.** `import math` at the caller module scope does NOT reach the sandbox, so a proposal that references `math.sqrt` without a local `import math` raises `NameError` on the first call. `self-heal` already hints at this in the LLM prompt when sandbox is active, but if you're writing a proposer by hand the same rule applies.
 
 ### Progress callbacks
+
 ```python
 from self_heal import repair, RepairEvent
 
@@ -157,9 +174,11 @@ def watch(event: RepairEvent):
 @repair(on_event=watch)
 def my_fn(...): ...
 ```
+
 Hooks fire on attempt start, failure, propose start/complete, install, cache hit/miss, safety violation, verify, and repair completion. Perfect for agent UIs and observability pipelines.
 
 ### Token streaming
+
 When a callback is registered, self-heal streams LLM tokens through `propose_chunk` events as they arrive:
 
 ```python
@@ -172,12 +191,28 @@ def on_event(event: RepairEvent):
 @repair(on_event=on_event)
 def my_fn(...): ...
 ```
-All four built-in proposers stream natively via their SDKs. Custom proposers can implement `propose_stream(system, user) -> Iterator[str]` (and `apropose_stream` for async) to participate; those without streaming fall back to a single completion. See [`examples/streaming_progress.py`](examples/streaming_progress.py).
+
+All four built-in proposers stream natively via their SDKs. Custom proposers can implement `propose_stream(system, user) -> Iterator[str]` (and `apropose_stream` for async) to participate; those without streaming fall back to a single completion. See `[examples/streaming_progress.py](examples/streaming_progress.py)`.
 
 ### Native async proposers
+
 `arun` prefers each SDK's native async client when the proposer provides `apropose`, falling back to `asyncio.to_thread(propose)` otherwise. All four built-in adapters ship with native async; custom proposers work either way.
 
+### Resilience: retry on transient provider errors
+
+Rate limits (429), service blips (502/503/504), and timeouts are common with LLM APIs. Pass a `RetryConfig` and self-heal will retry the proposer call with exponential backoff + jitter before giving up. Auth and validation errors are not retried.
+
+```python
+from self_heal import repair, RetryConfig
+
+@repair(retry_config=RetryConfig(max_retries=3, base_delay=1.0))
+def my_fn(...): ...
+```
+
+Defaults: 3 retries, 1s base delay, 2x backoff, ±25% jitter, capped at 30s. Retries do not count against `max_attempts` and each one fires a `transient_retry` event with `retry_attempt` and `retry_delay`. Set `retry_config=None` (the default) to disable retries.
+
 ### pytest plugin: `pytest --heal`
+
 Mark any test with `@pytest.mark.heal(target="mymod.my_fn")`. When it fails with `--heal`, self-heal loads the target, repairs it using the test as verification, and prints the proposed diff at the end of the session.
 
 ```python
@@ -188,19 +223,23 @@ from mymod import extract_price
 def test_rupees():
     assert extract_price("₹1,299") == 1299.0
 ```
+
 ```bash
 pytest --heal              # print proposed fix, leave files untouched
 pytest --heal-apply        # write the fix back to disk (creates a .py.heal-backup)
 pytest --heal-apply-force  # also allow modification of git-dirty files
 ```
+
 `--heal-apply` uses libcst for AST-faithful replacement when installed, falling back to textual replacement. It refuses to modify files with uncommitted git changes unless `--heal-apply-force` is given.
 
 ### CLI: heal a function from the command line
+
 ```bash
 self-heal heal mymod.py::extract_price \
     --test tests/test_mymod.py::test_rupees \
     --apply
 ```
+
 Loads the function, runs self-heal with your pytest-style test as verification, prints a unified diff, and (with `--apply`) writes the fix back to the file.
 
 ## Why this exists
@@ -254,12 +293,14 @@ result = await loop.arun(my_async_fn, args=(...))
 ## Using different providers
 
 **Claude (default):**
+
 ```python
 @repair()
 def my_fn(...): ...
 ```
 
 **OpenAI:**
+
 ```python
 from self_heal.llm import OpenAIProposer
 
@@ -268,6 +309,7 @@ def my_fn(...): ...
 ```
 
 **Gemini:**
+
 ```python
 from self_heal.llm import GeminiProposer
 
@@ -276,6 +318,7 @@ def my_fn(...): ...
 ```
 
 **Mistral:**
+
 ```python
 from self_heal.llm import MistralProposer
 
@@ -284,6 +327,7 @@ def my_fn(...): ...
 ```
 
 **Any OpenAI-compatible endpoint (OpenRouter, Groq, Ollama, ...):**
+
 ```python
 from self_heal.llm import OpenAIProposer
 
@@ -302,6 +346,7 @@ OpenAIProposer(
 ```
 
 **LiteLLM catch-all (100+ providers):**
+
 ```python
 from self_heal.llm import LiteLLMProposer
 
@@ -350,14 +395,14 @@ def price_from_text(text: str) -> float:
 
 ### Other frameworks (decorator stacking)
 
-Examples in [`examples/`](examples):
+Examples in `[examples/`
 
-- [`with_claude_agent_sdk.py`](examples/with_claude_agent_sdk.py)
-- [`with_openai_agents.py`](examples/with_openai_agents.py)
-- [`with_langchain.py`](examples/with_langchain.py)
-- [`with_crewai.py`](examples/with_crewai.py)
+- `[with_claude_agent_sdk.py](examples/with_claude_agent_sdk.py)`
+- `[with_openai_agents.py](examples/with_openai_agents.py)`
+- `[with_langchain.py](examples/with_langchain.py)`
+- `[with_crewai.py](examples/with_crewai.py)`
 
-All examples are smoke-tested on every CI run via [`tests/test_examples_import.py`](tests/test_examples_import.py).
+All examples are smoke-tested on every CI run via `[tests/test_examples_import.py](tests/test_examples_import.py)`.
 
 ## Safety
 
@@ -377,25 +422,25 @@ def parse_price(text: str) -> float:
 
 ## Roadmap
 
-- [x] v0.0.1: core repair loop + decorator + Claude backend
-- [x] v0.0.2: OpenAI, Gemini, LiteLLM adapters; works with any LLM
-- [x] v0.1.0: multi-turn memory, verifiers, test-driven repair, async, benchmark harness
-- [x] v0.2.0: repair cache, AST safety rails, event callbacks, pytest plugin, CLI, extended benchmarks
-- [x] v0.3.0: subprocess sandbox, `pytest --heal-apply`, QuixBugs benchmark, local-model sweep tooling
-- [x] v0.4.0: streaming token events (`propose_chunk`), native async proposers (`apropose`) for all four adapters
-- [x] **v0.4.1: sandbox preserves custom exceptions from proposals; `is_git_dirty` fails closed on timeout; Claude Agent SDK and LangChain/LangGraph first-class integrations**
-- [ ] v0.5: wasm sandbox, warm subprocess worker pool, first-class CrewAI / OpenAI Agents SDK integrations
-- [ ] v1.0: stable API + extended benchmark suite (HumanEval-Fix, Refactory)
+- v0.0.1: core repair loop + decorator + Claude backend
+- v0.0.2: OpenAI, Gemini, LiteLLM adapters; works with any LLM
+- v0.1.0: multi-turn memory, verifiers, test-driven repair, async, benchmark harness
+- v0.2.0: repair cache, AST safety rails, event callbacks, pytest plugin, CLI, extended benchmarks
+- v0.3.0: subprocess sandbox, `pytest --heal-apply`, QuixBugs benchmark, local-model sweep tooling
+- v0.4.0: streaming token events (`propose_chunk`), native async proposers (`apropose`) for all four adapters
+- **v0.4.1: sandbox preserves custom exceptions from proposals; `is_git_dirty` fails closed on timeout; Claude Agent SDK and LangChain/LangGraph first-class integrations**
+- v0.5: wasm sandbox, warm subprocess worker pool, first-class CrewAI / OpenAI Agents SDK integrations
+- v1.0: stable API + extended benchmark suite (HumanEval-Fix, Refactory)
 
 ## Deeper docs
 
-- [`docs/sandbox-threat-model.md`](docs/sandbox-threat-model.md): what the subprocess sandbox protects against and what it does not. Read before running against untrusted inputs.
-- [`docs/custom-proposer.md`](docs/custom-proposer.md): implementing the `LLMProposer` Protocol for an unsupported provider.
-- [`docs/faq.md`](docs/faq.md): positioning, cost, safety, integrations, contribution.
+- `[docs/sandbox-threat-model.md](docs/sandbox-threat-model.md)`: what the subprocess sandbox protects against and what it does not. Read before running against untrusted inputs.
+- `[docs/custom-proposer.md](docs/custom-proposer.md)`: implementing the `LLMProposer` Protocol for an unsupported provider.
+- `[docs/faq.md](docs/faq.md)`: positioning, cost, safety, integrations, contribution.
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full guide: dev setup, everyday commands, how to add a new LLM proposer or benchmark task, and the PR checklist. Good first issues are tagged [here](https://github.com/Johin2/self-heal/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+See `[CONTRIBUTING.md](CONTRIBUTING.md)` for the full guide: dev setup, everyday commands, how to add a new LLM proposer or benchmark task, and the PR checklist. Good first issues are tagged [here](https://github.com/Johin2/self-heal/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 
 ## Development (quick start)
 
@@ -410,6 +455,7 @@ ruff check .
 ```
 
 Run the benchmark locally:
+
 ```bash
 python benchmarks/run.py --proposer claude                       # uses ANTHROPIC_API_KEY
 python benchmarks/run.py --proposer openai                       # uses OPENAI_API_KEY

--- a/src/self_heal/__init__.py
+++ b/src/self_heal/__init__.py
@@ -9,6 +9,7 @@ from self_heal.core import repair
 from self_heal.events import EventCallback, RepairEvent
 from self_heal.llm import LLMProposer
 from self_heal.loop import RepairLoop
+from self_heal.retry import RetryConfig
 from self_heal.safety import SafetyConfig, UnsafeProposalError
 from self_heal.types import Failure, RepairAttempt, RepairResult
 from self_heal.verify import Test, Verifier, check_tests, check_verifier
@@ -64,6 +65,7 @@ __all__ = [
     "RepairEvent",
     "RepairLoop",
     "RepairResult",
+    "RetryConfig",
     "SafetyConfig",
     "Test",
     "TogetherProposer",

--- a/src/self_heal/core.py
+++ b/src/self_heal/core.py
@@ -12,6 +12,7 @@ from self_heal.cache import RepairCache
 from self_heal.events import EventCallback
 from self_heal.llm import LLMProposer
 from self_heal.loop import RepairLoop
+from self_heal.retry import RetryConfig
 from self_heal.safety import SafetyConfig, SafetyLevel
 from self_heal.verify import Test, Verifier
 
@@ -31,6 +32,7 @@ def repair(
     cache_path: str | Path | None = None,
     safety: SafetyConfig | SafetyLevel | None = None,
     on_event: EventCallback | None = None,
+    retry_config: RetryConfig | None = None,
 ) -> Callable[[F], F]:
     """Wrap a function in an LLM-backed repair loop.
 
@@ -82,6 +84,7 @@ def repair(
             cache=resolved_cache,
             safety=resolved_safety,
             on_event=on_event,
+            retry_config=retry_config,
         )
 
         is_async = inspect.iscoroutinefunction(func)

--- a/src/self_heal/events.py
+++ b/src/self_heal/events.py
@@ -33,7 +33,7 @@ EventType = Literal[
     "verify_success",
     "repair_succeeded",
     "repair_exhausted",
-    "retry",
+    "transient_retry",
 ]
 
 

--- a/src/self_heal/events.py
+++ b/src/self_heal/events.py
@@ -24,6 +24,7 @@ EventType = Literal[
     "propose_start",
     "propose_chunk",
     "propose_complete",
+    "stream_error",
     "install_success",
     "install_failed",
     "cache_hit",
@@ -32,6 +33,7 @@ EventType = Literal[
     "verify_success",
     "repair_succeeded",
     "repair_exhausted",
+    "retry",
 ]
 
 
@@ -45,6 +47,8 @@ class RepairEvent:
     proposed_source: str | None = None
     error: str | None = None
     delta: str | None = None
+    retry_attempt: int | None = None
+    retry_delay: float | None = None
     extra: dict[str, Any] | None = None
 
 

--- a/src/self_heal/loop.py
+++ b/src/self_heal/loop.py
@@ -282,7 +282,7 @@ class RepairLoop:
             emit(
                 self.on_event,
                 RepairEvent(
-                    "retry",
+                    "transient_retry",
                     attempt_number=len(ctx.attempts),
                     retry_attempt=retry_num,
                     retry_delay=delay,

--- a/src/self_heal/loop.py
+++ b/src/self_heal/loop.py
@@ -13,6 +13,7 @@ from self_heal.diagnose import classify
 from self_heal.events import EventCallback, RepairEvent, emit
 from self_heal.llm import LLMProposer
 from self_heal.propose import build_messages, extract_code
+from self_heal.retry import RetryConfig, awith_retry, with_retry
 from self_heal.safety import SafetyConfig, UnsafeProposalError, validate
 from self_heal.types import RepairAttempt, RepairResult
 from self_heal.verify import Test, Verifier, check_tests, check_verifier
@@ -69,6 +70,7 @@ class RepairLoop:
         cache: RepairCache | None = None,
         safety: SafetyConfig | None = None,
         on_event: EventCallback | None = None,
+        retry_config: RetryConfig | None = None,
     ):
         if max_attempts < 1:
             raise ValueError("max_attempts must be >= 1")
@@ -79,6 +81,7 @@ class RepairLoop:
         self.cache = cache
         self.safety = safety
         self.on_event = on_event
+        self._retry_config = retry_config
 
     @property
     def proposer(self) -> LLMProposer:
@@ -207,9 +210,9 @@ class RepairLoop:
                 raw = "".join(chunks)
             except Exception as stream_exc:
                 emit(self.on_event, RepairEvent("stream_error", error=str(stream_exc)))
-                raw = proposer.propose(system, user)
+                raw = self._run_propose(proposer, system, user, ctx)
         else:
-            raw = proposer.propose(system, user)
+            raw = self._run_propose(proposer, system, user, ctx)
 
         emit(
             self.on_event,
@@ -254,9 +257,9 @@ class RepairLoop:
                 raw = "".join(chunks)
             except Exception as stream_exc:
                 emit(self.on_event, RepairEvent("stream_error", error=str(stream_exc)))
-                raw = await self._acall_propose(proposer, system, user)
+                raw = await self._run_apropose(proposer, system, user, ctx)
         else:
-            raw = await self._acall_propose(proposer, system, user)
+            raw = await self._run_apropose(proposer, system, user, ctx)
 
         emit(
             self.on_event,
@@ -269,6 +272,49 @@ class RepairLoop:
         if hasattr(proposer, "apropose"):
             return await proposer.apropose(system, user)
         return await asyncio.to_thread(proposer.propose, system, user)
+
+    def _make_retry_callback(
+        self, ctx: _RunContext
+    ) -> Callable[[int, float, BaseException], None]:
+        """Return an on_retry callback that emits a retry RepairEvent."""
+
+        def _cb(retry_num: int, delay: float, exc: BaseException) -> None:
+            emit(
+                self.on_event,
+                RepairEvent(
+                    "retry",
+                    attempt_number=len(ctx.attempts),
+                    retry_attempt=retry_num,
+                    retry_delay=delay,
+                    error=str(exc),
+                ),
+            )
+
+        return _cb
+
+    def _run_propose(
+        self, proposer: LLMProposer, system: str, user: str, ctx: _RunContext
+    ) -> str:
+        """Invoke proposer.propose(), retrying on transient errors if configured."""
+        if self._retry_config is None:
+            return proposer.propose(system, user)
+        return with_retry(
+            lambda: proposer.propose(system, user),
+            self._retry_config,
+            self._make_retry_callback(ctx),
+        )
+
+    async def _run_apropose(
+        self, proposer: LLMProposer, system: str, user: str, ctx: _RunContext
+    ) -> str:
+        """Async proposer call with optional retry on transient errors."""
+        if self._retry_config is None:
+            return await self._acall_propose(proposer, system, user)
+        return await awith_retry(
+            lambda: self._acall_propose(proposer, system, user),
+            self._retry_config,
+            self._make_retry_callback(ctx),
+        )
 
     def _log(self, message: str) -> None:
         if self.verbose:

--- a/src/self_heal/retry.py
+++ b/src/self_heal/retry.py
@@ -1,0 +1,110 @@
+#Retry helpers for transient LLM provider errors (429, 503, timeouts)
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TypeVar
+
+T = TypeVar("T")
+
+_TRANSIENT_STATUS_CODES = {"429", "502", "503", "504"}
+_TRANSIENT_CLASS_NAMES = {
+    "RateLimitError",
+    "APITimeoutError",
+    "ServiceUnavailableError",
+    "Timeout",
+    "TimeoutError",
+    "ConnectTimeout",
+    "ReadTimeout",
+}
+_TRANSIENT_PHRASES = ("rate limit", "too many requests", "timeout", "service unavailable")
+
+
+@dataclass
+class RetryConfig:
+    """Policy for retrying transient LLM provider errors.
+
+    Args:
+        max_retries: Maximum number of retries after the initial attempt.
+        base_delay: Initial wait in seconds before the first retry.
+        max_delay: Upper cap on inter-retry delay (seconds).
+        backoff_factor: Multiplier applied to the delay after each retry.
+    """
+
+    max_retries: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 30.0
+    backoff_factor: float = 2.0
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """Return True if *exc* looks like a transient provider error worth retrying."""
+    if type(exc).__name__ in _TRANSIENT_CLASS_NAMES:
+        return True
+    msg = str(exc).lower()
+    if any(code in msg for code in _TRANSIENT_STATUS_CODES):
+        return True
+    return any(phrase in msg for phrase in _TRANSIENT_PHRASES)
+
+
+def with_retry(
+    fn: Callable[[], T],
+    config: RetryConfig,
+    on_retry: Callable[[int, float, BaseException], None] | None = None,
+) -> T:
+    """Call *fn()* and retry on transient errors using exponential backoff.
+
+    Args:
+        fn: Zero-argument callable to invoke.
+        config: Retry policy.
+        on_retry: Optional callback invoked before each retry with
+            ``(retry_number, delay_seconds, exception)``.
+
+    Raises:
+        The original exception if it is not transient or retries are exhausted.
+    """
+    for attempt in range(config.max_retries + 1):
+        try:
+            return fn()
+        except Exception as exc:
+            if not _is_transient(exc) or attempt == config.max_retries:
+                raise
+            delay = min(
+                config.base_delay * config.backoff_factor**attempt,
+                config.max_delay,
+            )
+            if on_retry is not None:
+                on_retry(attempt + 1, delay, exc)
+            time.sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+async def awith_retry(
+    afn: Callable[[], Awaitable[T]],
+    config: RetryConfig,
+    on_retry: Callable[[int, float, BaseException], None] | None = None,
+) -> T:
+    """Async variant of :func:`with_retry`.
+
+    Args:
+        afn: Zero-argument async callable (or callable returning an awaitable).
+        config: Retry policy.
+        on_retry: Optional callback invoked before each retry.
+    """
+    for attempt in range(config.max_retries + 1):
+        try:
+            return await afn()
+        except Exception as exc:
+            if not _is_transient(exc) or attempt == config.max_retries:
+                raise
+            delay = min(
+                config.base_delay * config.backoff_factor**attempt,
+                config.max_delay,
+            )
+            if on_retry is not None:
+                on_retry(attempt + 1, delay, exc)
+            await asyncio.sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover

--- a/src/self_heal/retry.py
+++ b/src/self_heal/retry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import random
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -14,11 +15,14 @@ _TRANSIENT_STATUS_CODES = {"429", "502", "503", "504"}
 _TRANSIENT_CLASS_NAMES = {
     "RateLimitError",
     "APITimeoutError",
+    "APIConnectionError",
     "ServiceUnavailableError",
     "Timeout",
     "TimeoutError",
+    "TimeoutException",
     "ConnectTimeout",
     "ReadTimeout",
+    "RemoteProtocolError",
 }
 _TRANSIENT_PHRASES = ("rate limit", "too many requests", "timeout", "service unavailable")
 
@@ -32,12 +36,23 @@ class RetryConfig:
         base_delay: Initial wait in seconds before the first retry.
         max_delay: Upper cap on inter-retry delay (seconds).
         backoff_factor: Multiplier applied to the delay after each retry.
+        jitter: Fractional jitter applied to each delay (0.25 = ±25%).
+            Set to 0 to disable.
     """
 
     max_retries: int = 3
     base_delay: float = 1.0
     max_delay: float = 30.0
     backoff_factor: float = 2.0
+    jitter: float = 0.25
+
+
+def _compute_delay(config: RetryConfig, attempt: int) -> float:
+    """Exponential backoff with bounded random jitter, capped at max_delay."""
+    raw = config.base_delay * config.backoff_factor**attempt
+    if config.jitter > 0:
+        raw *= 1.0 + random.uniform(-config.jitter, config.jitter)
+    return min(max(raw, 0.0), config.max_delay)
 
 
 def _is_transient(exc: BaseException) -> bool:
@@ -72,10 +87,7 @@ def with_retry(
         except Exception as exc:
             if not _is_transient(exc) or attempt == config.max_retries:
                 raise
-            delay = min(
-                config.base_delay * config.backoff_factor**attempt,
-                config.max_delay,
-            )
+            delay = _compute_delay(config, attempt)
             if on_retry is not None:
                 on_retry(attempt + 1, delay, exc)
             time.sleep(delay)
@@ -100,10 +112,7 @@ async def awith_retry(
         except Exception as exc:
             if not _is_transient(exc) or attempt == config.max_retries:
                 raise
-            delay = min(
-                config.base_delay * config.backoff_factor**attempt,
-                config.max_delay,
-            )
+            delay = _compute_delay(config, attempt)
             if on_retry is not None:
                 on_retry(attempt + 1, delay, exc)
             await asyncio.sleep(delay)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,431 @@
+"""Tests for retry-with-backoff on transient proposer errors (issue #32).
+
+All tests that involve actual delays use base_delay=0.0 so asyncio.sleep(0)
+and time.sleep(0) are called, which are effectively instant.  Tests that
+validate delay *values* patch the sleep functions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from self_heal import RepairEvent, RepairLoop, RetryConfig
+from self_heal.retry import _is_transient, awith_retry, with_retry
+
+
+# _is_transient classification
+
+
+def test_is_transient_429_in_message():
+    assert _is_transient(Exception("HTTP 429 Too Many Requests"))
+
+
+def test_is_transient_503_in_message():
+    assert _is_transient(Exception("503 Service Unavailable"))
+
+
+def test_is_transient_502_in_message():
+    assert _is_transient(Exception("502 Bad Gateway"))
+
+
+def test_is_transient_timeout_phrase():
+    assert _is_transient(Exception("connection timeout after 30s"))
+
+
+def test_is_transient_rate_limit_phrase():
+    assert _is_transient(Exception("rate limit exceeded, retry after 60s"))
+
+
+def test_is_transient_by_exception_class_name_rate_limit():
+    class RateLimitError(Exception):
+        pass
+
+    assert _is_transient(RateLimitError("you hit the rate limit"))
+
+
+def test_is_transient_by_exception_class_name_timeout():
+    class ConnectTimeout(Exception):
+        pass
+
+    assert _is_transient(ConnectTimeout("connection timed out"))
+
+
+def test_is_transient_by_exception_class_name_api_timeout():
+    class APITimeoutError(Exception):
+        pass
+
+    assert _is_transient(APITimeoutError("request timed out"))
+
+
+def test_not_transient_401():
+    assert not _is_transient(Exception("401 Unauthorized: invalid API key"))
+
+
+def test_not_transient_400():
+    assert not _is_transient(Exception("400 Bad Request: missing required field"))
+
+
+def test_not_transient_generic_value_error():
+    assert not _is_transient(ValueError("wrong type provided"))
+
+
+def test_not_transient_generic_runtime_error():
+    assert not _is_transient(RuntimeError("something unexpected happened"))
+
+
+# with_retry unit tests
+
+
+def test_with_retry_returns_immediately_on_success():
+    result = with_retry(lambda: "ok", RetryConfig(max_retries=3))
+    assert result == "ok"
+
+
+def test_with_retry_retries_transient_and_succeeds():
+    calls: list[int] = []
+
+    def fn():
+        calls.append(1)
+        if len(calls) < 3:
+            raise Exception("429 rate limit exceeded")
+        return "success"
+
+    with patch("self_heal.retry.time.sleep"):
+        result = with_retry(fn, RetryConfig(max_retries=3, base_delay=1.0))
+
+    assert result == "success"
+    assert len(calls) == 3
+
+
+def test_with_retry_does_not_retry_non_transient():
+    calls: list[int] = []
+
+    def fn():
+        calls.append(1)
+        raise ValueError("not a transient error")
+
+    with pytest.raises(ValueError, match="not a transient error"):
+        with_retry(fn, RetryConfig(max_retries=3))
+
+    assert len(calls) == 1
+
+
+def test_with_retry_raises_original_after_exhausting_retries():
+    calls: list[int] = []
+
+    def fn():
+        calls.append(1)
+        raise Exception("503 temporarily unavailable")
+
+    with patch("self_heal.retry.time.sleep"), pytest.raises(Exception, match="503"):
+        with_retry(fn, RetryConfig(max_retries=2, base_delay=1.0))
+
+    assert len(calls) == 3  # 1 initial + 2 retries
+
+
+def test_with_retry_invokes_on_retry_callback():
+    retry_calls: list[tuple[int, float]] = []
+    calls: list[int] = []
+
+    def fn():
+        calls.append(1)
+        if len(calls) < 3:
+            raise Exception("429")
+        return "ok"
+
+    with patch("self_heal.retry.time.sleep"):
+        with_retry(
+            fn,
+            RetryConfig(max_retries=3, base_delay=1.0, backoff_factor=2.0),
+            on_retry=lambda n, d, e: retry_calls.append((n, d)),
+        )
+
+    assert retry_calls == [(1, 1.0), (2, 2.0)]
+
+
+def test_with_retry_caps_delay_at_max_delay():
+    delays: list[float] = []
+
+    def fn():
+        raise Exception("429")
+
+    with patch("self_heal.retry.time.sleep"), pytest.raises(Exception, match="429"):
+        with_retry(
+            fn,
+            RetryConfig(max_retries=5, base_delay=10.0, backoff_factor=10.0, max_delay=30.0),
+            on_retry=lambda n, d, e: delays.append(d),
+        )
+
+    assert len(delays) == 5
+    assert all(d <= 30.0 for d in delays)
+
+
+# awith_retry unit tests
+
+
+def test_awith_retry_returns_immediately_on_success():
+    async def afn():
+        return "async ok"
+
+    result = asyncio.run(awith_retry(afn, RetryConfig(max_retries=3, base_delay=0.0)))
+    assert result == "async ok"
+
+
+def test_awith_retry_retries_transient_and_succeeds():
+    calls: list[int] = []
+
+    async def afn():
+        calls.append(1)
+        if len(calls) < 2:
+            raise Exception("429 rate limit")
+        return "fixed"
+
+    result = asyncio.run(awith_retry(afn, RetryConfig(max_retries=3, base_delay=0.0)))
+    assert result == "fixed"
+    assert len(calls) == 2
+
+
+def test_awith_retry_does_not_retry_non_transient():
+    calls: list[int] = []
+
+    async def afn():
+        calls.append(1)
+        raise TypeError("bad type")
+
+    with pytest.raises(TypeError):
+        asyncio.run(awith_retry(afn, RetryConfig(max_retries=3, base_delay=0.0)))
+
+    assert len(calls) == 1
+
+
+def test_awith_retry_raises_after_exhausting_retries():
+    calls: list[int] = []
+
+    async def afn():
+        calls.append(1)
+        raise Exception("503")
+
+    with pytest.raises(Exception, match="503"):
+        asyncio.run(awith_retry(afn, RetryConfig(max_retries=2, base_delay=0.0)))
+
+    assert len(calls) == 3
+
+
+# RepairLoop integration: sync
+
+
+def test_repair_loop_retries_proposer_on_429():
+    calls: list[int] = []
+
+    class FlakyProposer:
+        def propose(self, system, user):
+            calls.append(1)
+            if len(calls) == 1:
+                raise Exception("429 Too Many Requests")
+            return "def broken(x):\n    return x * 2\n"
+
+    loop = RepairLoop(
+        max_attempts=2,
+        proposer=FlakyProposer(),
+        retry_config=RetryConfig(max_retries=3, base_delay=0.0),
+    )
+
+    def broken(x):
+        return None
+
+    result = loop.run(broken, args=(5,), verify=lambda v: v == 10)
+    assert result.succeeded
+    assert len(calls) == 2  # 1 transient failure + 1 successful retry
+
+
+def test_repair_loop_retries_proposer_on_503():
+    calls: list[int] = []
+
+    class FlakyProposer:
+        def propose(self, system, user):
+            calls.append(1)
+            if len(calls) < 3:
+                raise Exception("503 Service Unavailable")
+            return "def broken(x):\n    return x * 2\n"
+
+    loop = RepairLoop(
+        max_attempts=2,
+        proposer=FlakyProposer(),
+        retry_config=RetryConfig(max_retries=3, base_delay=0.0),
+    )
+
+    def broken(x):
+        return None
+
+    result = loop.run(broken, args=(5,), verify=lambda v: v == 10)
+    assert result.succeeded
+    assert len(calls) == 3
+
+
+def test_repair_loop_no_retry_on_auth_error():
+    calls: list[int] = []
+
+    class AuthErrorProposer:
+        def propose(self, system, user):
+            calls.append(1)
+            raise Exception("401 Unauthorized: invalid API key")
+
+    loop = RepairLoop(
+        max_attempts=2,
+        proposer=AuthErrorProposer(),
+        retry_config=RetryConfig(max_retries=3, base_delay=0.0),
+    )
+
+    def broken(x):
+        return None
+
+    with pytest.raises(Exception, match="401"):
+        loop.run(broken, args=(5,), verify=lambda v: v == 10)
+
+    assert len(calls) == 1  # not retried
+
+
+def test_repair_loop_exhausted_retries_propagates_exception():
+    class AlwaysRateLimited:
+        def propose(self, system, user):
+            raise Exception("429 rate limit")
+
+    loop = RepairLoop(
+        max_attempts=2,
+        proposer=AlwaysRateLimited(),
+        retry_config=RetryConfig(max_retries=2, base_delay=0.0),
+    )
+
+    def broken(x):
+        return None
+
+    with pytest.raises(Exception, match="429"):
+        loop.run(broken, args=(5,), verify=lambda v: v == 10)
+
+
+def test_repair_loop_emits_retry_events():
+    calls: list[int] = []
+    events: list[RepairEvent] = []
+
+    class FlakyProposer:
+        def propose(self, system, user):
+            calls.append(1)
+            if len(calls) < 3:
+                raise Exception("503 Service Unavailable")
+            return "def broken(x):\n    return x * 2\n"
+
+    loop = RepairLoop(
+        max_attempts=2,
+        proposer=FlakyProposer(),
+        retry_config=RetryConfig(max_retries=3, base_delay=0.0),
+        on_event=lambda e: events.append(e),
+    )
+
+    def broken(x):
+        return None
+
+    result = loop.run(broken, args=(5,), verify=lambda v: v == 10)
+    assert result.succeeded
+
+    retry_events = [e for e in events if e.type == "retry"]
+    assert len(retry_events) == 2
+    assert retry_events[0].retry_attempt == 1
+    assert retry_events[1].retry_attempt == 2
+    assert retry_events[0].retry_delay is not None
+    assert retry_events[0].error is not None
+
+
+def test_repair_loop_without_retry_config_propagates_transient():
+    class TransientProposer:
+        def propose(self, system, user):
+            raise Exception("429 rate limit — no retry configured")
+
+    loop = RepairLoop(
+        max_attempts=2,
+        proposer=TransientProposer(),
+        # no retry_config
+    )
+
+    def broken(x):
+        return None
+
+    with pytest.raises(Exception, match="429"):
+        loop.run(broken, args=(5,), verify=lambda v: v == 10)
+
+
+# RepairLoop integration: async
+
+
+def test_repair_loop_async_retry_on_503():
+    calls: list[int] = []
+
+    class FlakyProposer:
+        def propose(self, system, user):
+            calls.append(1)
+            if len(calls) == 1:
+                raise Exception("503")
+            return "def broken(x):\n    return x * 2\n"
+
+    loop = RepairLoop(
+        max_attempts=2,
+        proposer=FlakyProposer(),
+        retry_config=RetryConfig(max_retries=3, base_delay=0.0),
+    )
+
+    def broken(x):
+        return None
+
+    result = asyncio.run(loop.arun(broken, args=(5,), verify=lambda v: v == 10))
+    assert result.succeeded
+    assert len(calls) == 2
+
+
+def test_repair_loop_async_emits_retry_events():
+    calls: list[int] = []
+    events: list[RepairEvent] = []
+
+    class FlakyProposer:
+        def propose(self, system, user):
+            calls.append(1)
+            if len(calls) < 2:
+                raise Exception("429")
+            return "def broken(x):\n    return x * 2\n"
+
+    loop = RepairLoop(
+        max_attempts=2,
+        proposer=FlakyProposer(),
+        retry_config=RetryConfig(max_retries=3, base_delay=0.0),
+        on_event=lambda e: events.append(e),
+    )
+
+    def broken(x):
+        return None
+
+    result = asyncio.run(loop.arun(broken, args=(5,), verify=lambda v: v == 10))
+    assert result.succeeded
+
+    retry_events = [e for e in events if e.type == "retry"]
+    assert len(retry_events) == 1
+    assert retry_events[0].retry_attempt == 1
+
+
+# Public API
+
+
+def test_retry_config_importable_from_self_heal():
+    from self_heal import RetryConfig as RC
+
+    cfg = RC(max_retries=5, base_delay=0.5)
+    assert cfg.max_retries == 5
+    assert cfg.base_delay == 0.5
+    assert cfg.max_delay == 30.0  # default
+    assert cfg.backoff_factor == 2.0  # default
+
+
+def test_retry_config_in_all():
+    import self_heal
+
+    assert "RetryConfig" in self_heal.__all__

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -15,7 +15,6 @@ import pytest
 from self_heal import RepairEvent, RepairLoop, RetryConfig
 from self_heal.retry import _is_transient, awith_retry, with_retry
 
-
 # _is_transient classification
 
 
@@ -139,11 +138,30 @@ def test_with_retry_invokes_on_retry_callback():
     with patch("self_heal.retry.time.sleep"):
         with_retry(
             fn,
-            RetryConfig(max_retries=3, base_delay=1.0, backoff_factor=2.0),
+            RetryConfig(max_retries=3, base_delay=1.0, backoff_factor=2.0, jitter=0),
             on_retry=lambda n, d, e: retry_calls.append((n, d)),
         )
 
     assert retry_calls == [(1, 1.0), (2, 2.0)]
+
+
+def test_with_retry_applies_jitter():
+    delays: list[float] = []
+
+    def fn():
+        if len(delays) < 4:
+            raise Exception("429")
+        return "ok"
+
+    with patch("self_heal.retry.time.sleep"):
+        with_retry(
+            fn,
+            RetryConfig(max_retries=5, base_delay=1.0, backoff_factor=1.0, jitter=0.25),
+            on_retry=lambda n, d, e: delays.append(d),
+        )
+
+    assert all(0.75 <= d <= 1.25 for d in delays)
+    assert len(set(delays)) > 1
 
 
 def test_with_retry_caps_delay_at_max_delay():
@@ -330,7 +348,7 @@ def test_repair_loop_emits_retry_events():
     result = loop.run(broken, args=(5,), verify=lambda v: v == 10)
     assert result.succeeded
 
-    retry_events = [e for e in events if e.type == "retry"]
+    retry_events = [e for e in events if e.type == "transient_retry"]
     assert len(retry_events) == 2
     assert retry_events[0].retry_attempt == 1
     assert retry_events[1].retry_attempt == 2
@@ -407,7 +425,7 @@ def test_repair_loop_async_emits_retry_events():
     result = asyncio.run(loop.arun(broken, args=(5,), verify=lambda v: v == 10))
     assert result.succeeded
 
-    retry_events = [e for e in events if e.type == "retry"]
+    retry_events = [e for e in events if e.type == "transient_retry"]
     assert len(retry_events) == 1
     assert retry_events[0].retry_attempt == 1
 


### PR DESCRIPTION
## Summary
- Add `RetryConfig` + `with_retry`/`awith_retry` helpers in `retry.py` for exponential backoff with bounded jitter on transient provider errors (429/502/503/504, timeouts, rate limits).
- Wire `retry_config` through `RepairLoop` and the `@repair` decorator; transient errors during the LLM propose call are retried, others fail fast.
- Emit a `transient_retry` event so retries are observable via `on_event`.
- Export `RetryConfig` from the package and document the feature in the README.

## Test plan
- [x] `tests/test_retry.py` (33 tests): classification, sync/async retry, exhaustion, no-retry on auth errors, event emission, public API export.

Closes #32.