### PR TITLE
fix(cache): don't overwrite a successful repair with a later failure

### DIFF
--- a/src/self_heal/cache.py
+++ b/src/self_heal/cache.py
@@ -90,6 +90,7 @@ class RepairCache:
                     proposed_source = excluded.proposed_source,
                     succeeded = excluded.succeeded,
                     created_at = excluded.created_at
+                WHERE excluded.succeeded = 1 OR repairs.succeeded = 0
                 """,
                 (
                     sh,

--- a/tests/test_v02_features.py
+++ b/tests/test_v02_features.py
@@ -74,6 +74,36 @@ def test_cache_miss_for_different_failure(tmp_path):
     cache.close()
 
 
+def test_cache_success_not_overwritten_by_later_failure(tmp_path):
+    # A previously cached successful repair must survive a later failed
+    # attempt for the same (source, failure) key. Regression test for #46.
+    cache = RepairCache(tmp_path / "cache.db")
+    fail = Failure(kind="exception", error_type="ValueError", message="boom")
+    src = "def f(): pass"
+
+    cache.record(src, fail, "def f(): return 1", succeeded=True)
+    cache.record(src, fail, "def f(): return bad", succeeded=False)
+
+    assert cache.lookup(src, fail) == "def f(): return 1"
+
+    cache.close()
+
+
+def test_cache_failure_upgraded_by_later_success(tmp_path):
+    # A failed entry should still be replaced when a success arrives.
+    cache = RepairCache(tmp_path / "cache.db")
+    fail = Failure(kind="exception", error_type="ValueError", message="boom")
+    src = "def f(): pass"
+
+    cache.record(src, fail, "def f(): return bad", succeeded=False)
+    assert cache.lookup(src, fail) is None
+
+    cache.record(src, fail, "def f(): return 1", succeeded=True)
+    assert cache.lookup(src, fail) == "def f(): return 1"
+
+    cache.close()
+
+
 # ---------------------------------------------------------------------------
 # Safety rails
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `RepairCache.record()` used an unconditional `ON CONFLICT DO UPDATE`, so a later failed attempt for the same `(source_hash, failure_signature)` key downgraded a previously cached successful repair to `succeeded=0`. Since `lookup()` only returns `succeeded=1` rows, a known-good repair silently disappeared from the cache.
- Guard the upsert with `WHERE excluded.succeeded = 1 OR repairs.succeeded = 0`: a success is never replaced by a failure, but a failed entry can still be upgraded to a success.

## Test plan
- [x] `test_cache_success_not_overwritten_by_later_failure` — record(success) then record(failure) → lookup still returns the success.
- [x] `test_cache_failure_upgraded_by_later_success` — record(failure) then record(success) → lookup returns the success.
- [x] Existing cache tests in `tests/test_v02_features.py` still pass (17/17 locally).

Closes #46.